### PR TITLE
feat: added missing static methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,176 @@ Update the New Relic Cordova plugin to the latest released version easily via th
 cordova plugin update
 ```
 
+# Usage
+See the examples below and for more detail see: [New Relic IOS SDK doc](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api) or [Android SDK](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api).
+
+### [noticeHttpTransaction](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/notice-http-transaction)(url: string, method: string, status: number, startTime: number, endTime: number, bytesSent: number, bytesReceived: number, body?: string)
+> The New Relic Cordova plugin automatically collects HTTP transactions, but if you want to manually record HTTP transactions, use this method to do so.
+  ```js
+      NewRelic.noticeHttpTransaction('https://fakewebsiteurl.com', 'GET', 200, Date.now(), Date.now(), 0, 100000, 'fake request body');
+  ```
+
+### [setUserId](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-user-id)(userId: string): void;
+> Set a custom user identifier value to associate user sessions with analytics events and attributes.
+  ```js
+     NewRelic.setUserId("CORDOVA12934");
+  ```
+
+### [setAttribute](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-attribute)(name: string, value: boolean | number | string): void;
+> Creates a session-level attribute shared by multiple mobile event types. Overwrites its previous value and type each time it is called.
+  ```js
+     NewRelic.setAttribute('CordovaCustomAttrNumber', 37);
+  ```
+
+
+### [removeAttribute](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/remove-attribute)(name: string, value: boolean | number | string): void;
+> This method removes the attribute specified by the name string..
+  ```js
+     NewRelic.removeAttribute('CordovaCustomAttrNumber');
+  ```
+
+### [incrementAttribute](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/increment-attribute)(name: string, value?: number): void;
+> Increments the count of an attribute with a specified name. Overwrites its previous value and type each time it is called. If the attribute does not exists, it creates a new attribute. If no value is given, it increments the value by 1.
+```js
+    NewRelic.incrementAttribute('CordovaCustomAttrNumber');
+    NewRelic.incrementAttribute('CordovaCustomAttrNumber', 5);
+```
+
+### [removeAllAttributes](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/remove-all-attributes)(): void;
+> Removes all attributes from the session
+```js
+    NewRelic.removeAllAttributes();
+```
+
+### [recordBreadcrumb](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordbreadcrumb)(name: string, attributes?: {[key: string]: boolean | number | string}): void;
+> Track app activity/screen that may be helpful for troubleshooting crashes.
+
+  ```js
+     NewRelic.recordBreadcrumb("shoe", {"shoeColor": "blue","shoesize": 9,"shoeLaces": true});
+  ```
+
+### [recordCustomEvent](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordcustomevent-android-sdk-api)(eventType: string, eventName?: string, attributes?: {[key: string]: boolean | number | string}): void;
+> Creates and records a custom event for use in New Relic Insights.
+
+  ```js
+     NewRelic.recordCustomEvent("mobileClothes", "pants", {"pantsColor": "blue","pantssize": 32,"belt": true});
+  ```
+
+### [startInteraction](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/start-interaction)(interactionName: string, cb?: function): Promise&lt;InteractionId&gt;;
+> Track a method as an interaction.
+
+### [endInteraction](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/end-interaction)(id: InteractionId): void;
+> End an interaction
+> (Required). This uses the string ID for the interaction you want to end.
+> This string is returned when you use startInteraction() and as a parameter to the provided callback function.
+
+  ```js
+   const badApiLoad = async () => {
+     const interactionId = await NewRelic.startInteraction('StartLoadBadApiCall');
+     console.log(interactionId);
+     const url = 'https://cordova.apache.org/moviessssssssss.json';
+     fetch(url)
+       .then((response) => response.json())
+       .then((responseJson) => {
+         console.log(responseJson);
+         NewRelic.endInteraction(interactionId);
+       }) .catch((error) => {
+         NewRelic.endInteraction(interactionId);
+         console.error(error);
+       });
+  
+  ```
+
+### recordError(name: string, message: string, stack: string, isFatal: boolean): void;
+> Records JavaScript errors for Cordova.
+```js
+    try {
+      var foo = {};
+      foo.bar();
+    } catch(err) {
+      NewRelic.recordError(err.name, err.message, err.stack, true);
+    }
+```
+
+### [crashNow](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/crashnow-android-sdk-api)(message?: string): void;
+> Throws a demo run-time exception to test New Relic crash reporting.
+
+```js
+    NewRelic.crashNow();
+    NewRelic.crashNow("New Relic example crash message");
+```
+
+### [currentSessionId](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/currentsessionid-android-sdk-api)(): Promise&lt;sessionId&gt;;
+> Returns the current session ID. This method is useful for consolidating monitoring of app data (not just New Relic data) based on a single session definition and identifier.
+```js
+    let sessionId = await NewRelic.currentSessionId();
+```
+
+### [noticeNetworkFailure](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/notice-network-failure)(url: string, httpMethod: string, startTime: number, endTime: number, failure: string): void;
+> Records network failures. If a network request fails, use this method to record details about the failures. In most cases, place this call inside exception handlers, such as catch blocks. Supported failures are: `Unknown`, `BadURL`, `TimedOut`, `CannotConnectToHost`, `DNSLookupFailed`, `BadServerResponse`, `SecureConnectionFailed`
+```js
+    NewRelic.noticeNetworkFailure('https://fakewebsite.com', 'GET', Date.now(), Date.now(), 'BadURL');
+```
+
+### [recordMetric](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordmetric-android-sdk-api)(name: string, category: string, value?: number, countUnit?: string, valueUnit?: string): void;
+> Records custom metrics (arbitrary numerical data), where countUnit is the measurement unit of the metric count and valueUnit is the measurement unit for the metric value. If using countUnit or valueUnit, then all of value, countUnit, and valueUnit must all be set. Supported measurements for countUnit and valueUnit are: `PERCENT`, `BYTES`, `SECONDS`, `BYTES_PER_SECOND`, `OPERATIONS`
+```js
+    NewRelic.recordMetric('CordovaCustomMetricName', 'CordovaCustomMetricCategory');
+    NewRelic.recordMetric('CordovaCustomMetricName', 'CordovaCustomMetricCategory', 12);
+    NewRelic.recordMetric('CordovaCustomMetricName', 'CordovaCustomMetricCategory', 13, 'PERCENT', 'SECONDS');
+```
+
+### [setMaxEventBufferTime](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-buffer-time)(maxBufferTimeInSeconds: number): void;
+> Sets the event harvest cycle length. Default is 600 seconds (10 minutes). Minimum value can not be less than 60 seconds. Maximum value should not be greater than 600 seconds.
+```js
+    NewRelic.setMaxEventBufferTime(60);
+```
+
+### [setMaxEventPoolSize](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-pool-size)(maxSize: number): void;
+> Sets the maximum size of the event pool stored in memory until the next harvest cycle. Default is a maximum of 1000 events per event harvest cycle. When the pool size limit is reached, the agent will start sampling events, discarding some new and old, until the pool of events is sent in the next harvest cycle.
+```js
+    NewRelic.setMaxEventPoolSize(2000);
+```
+
+### The following methods allow you to set some agent configurations *after* the agent has started:
+By default, these configurations are already set to true on agent start.
+
+### [analyticsEventEnabled](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags/#ff-analytics-events)(enabled: boolean) : void;
+> FOR ANDROID ONLY. Enable or disable the collecton of event data.
+```js
+    NewRelic.analyticsEventEnabled(true);
+```
+
+### [networkRequestEnabled](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags/#ff-networkRequests)(enabled: boolean) : void;
+> Enable or disable reporting successful HTTP requests to the MobileRequest event type.
+```js
+    NewRelic.networkRequestEnabled(true);
+```
+
+### [networkErrorRequestEnabled](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags/#ff-networkErrorRequests)(enabled: boolean) : void;
+> Enable or disable reporting network and HTTP request errors to the MobileRequestError event type.
+```js
+    NewRelic.networkErrorRequestEnabled(true);
+```
+
+### [httpRequestBodyCaptureEnabled](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags/#ff-withHttpResponseBodyCaptureEnabled)(enabled: boolean) : void;
+> Enable or disable capture of HTTP response bodies for HTTP error traces, and MobileRequestError events.
+```js
+    NewRelic.httpRequestBodyCaptureEnabled(true);
+```
+
+## How to see JSErrors(Fatal/Non Fatal) in NewRelic One?
+
+There is no section for JavaScript errors, but you can see JavaScript errors in custom events and also query them in NRQL explorer.
+
+<img width="1753" alt="Screen Shot 2022-02-10 at 12 41 11 PM" src="https://user-images.githubusercontent.com/89222514/153474861-87213e70-c3fb-4e14-aee7-a6a3fb482f73.png">
+
+You can also build dashboard for errors using this query:
+
+  ```sql
+  SELECT jsAppVersion,name,Message,errorStack,isFatal FROM `JS Errors` SINCE 24 hours ago
+  ```
+
 # Contributing Code
 
 We welcome code contributions (in the form of pull requests) from our user community. Before submitting a pull request please review [these guidelines](CONTRIBUTING.md).

--- a/src/android/NewRelicCordovaPlugin.java
+++ b/src/android/NewRelicCordovaPlugin.java
@@ -263,42 +263,42 @@ public class NewRelicCordovaPlugin extends CordovaPlugin {
                     NewRelic.setMaxEventPoolSize(maxPoolSize);
                     break;
                 }
-                // case "analyticsEventEnabled": {
-                //     final boolean enabled = args.getBoolean(0);
-                //     if(enabled) {
-                //         NewRelic.enableFeature(FeatureFlag.AnalyticsEvents);
-                //     } else {
-                //         NewRelic.disableFeature(FeatureFlag.AnalyticsEvents);
-                //     }
-                //     break;
-                // }
-                // case "networkRequestEnabled": {
-                //     final boolean enabled = args.getBoolean(0);
-                //     if(enabled) {
-                //         NewRelic.enableFeature(FeatureFlag.NetworkRequests);
-                //     } else {
-                //         NewRelic.disableFeature(FeatureFlag.NetworkRequests);
-                //     }
-                //     break;
-                // }
-                // case "networkErrorRequestEnabled": {
-                //     final boolean enabled = args.getBoolean(0);
-                //     if(enabled) {
-                //         NewRelic.enableFeature(FeatureFlag.NetworkErrorRequests);
-                //     } else {
-                //         NewRelic.disableFeature(FeatureFlag.NetworkErrorRequests);
-                //     }
-                //     break;
-                // }
-                // case "httpRequestBodyCaptureEnabled": {
-                //     final boolean enabled = args.getBoolean(0);
-                //     if(enabled) {
-                //         NewRelic.enableFeature(FeatureFlag.HttpResponseBodyCapture);
-                //     } else {
-                //         NewRelic.disableFeature(FeatureFlag.HttpResponseBodyCapture);
-                //     }
-                //     break;
-                // }
+                case "analyticsEventEnabled": {
+                    final boolean enabled = args.getBoolean(0);
+                    if(enabled) {
+                        NewRelic.enableFeature(FeatureFlag.AnalyticsEvents);
+                    } else {
+                        NewRelic.disableFeature(FeatureFlag.AnalyticsEvents);
+                    }
+                    break;
+                }
+                case "networkRequestEnabled": {
+                    final boolean enabled = args.getBoolean(0);
+                    if(enabled) {
+                        NewRelic.enableFeature(FeatureFlag.NetworkRequests);
+                    } else {
+                        NewRelic.disableFeature(FeatureFlag.NetworkRequests);
+                    }
+                    break;
+                }
+                case "networkErrorRequestEnabled": {
+                    final boolean enabled = args.getBoolean(0);
+                    if(enabled) {
+                        NewRelic.enableFeature(FeatureFlag.NetworkErrorRequests);
+                    } else {
+                        NewRelic.disableFeature(FeatureFlag.NetworkErrorRequests);
+                    }
+                    break;
+                }
+                case "httpRequestBodyCaptureEnabled": {
+                    final boolean enabled = args.getBoolean(0);
+                    if(enabled) {
+                        NewRelic.enableFeature(FeatureFlag.HttpResponseBodyCapture);
+                    } else {
+                        NewRelic.disableFeature(FeatureFlag.HttpResponseBodyCapture);
+                    }
+                    break;
+                }
                 
             }
         } catch (Exception e) {

--- a/src/android/NewRelicCordovaPlugin.java
+++ b/src/android/NewRelicCordovaPlugin.java
@@ -19,6 +19,9 @@ import com.newrelic.agent.android.distributedtracing.TraceContext;
 import com.newrelic.agent.android.distributedtracing.TraceHeader;
 import com.newrelic.agent.android.harvest.DeviceInformation;
 import com.newrelic.agent.android.stats.StatsEngine;
+import com.newrelic.agent.android.metric.MetricUnit;
+import com.newrelic.agent.android.util.NetworkFailure;
+import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.com.google.gson.Gson;
 
 import org.apache.cordova.CallbackContext;
@@ -145,7 +148,7 @@ public class NewRelicCordovaPlugin extends CordovaPlugin {
 
                     break;
                 }
-                case "noticeHttpTransaction":
+                case "noticeHttpTransaction": {
                     final String url = args.getString(0);
                     final String method = args.getString(1);
                     final int status = args.getInt(2);
@@ -158,7 +161,8 @@ public class NewRelicCordovaPlugin extends CordovaPlugin {
                     NewRelic.noticeHttpTransaction(url, method, status, startTime, endTime, bytesSent, bytesReceived,
                             body);
                     break;
-                case "noticeDistributedTrace":
+                }
+                case "noticeDistributedTrace": {
 
                     cordova.getThreadPool().execute(new Runnable() {
                         public void run() {
@@ -179,6 +183,123 @@ public class NewRelicCordovaPlugin extends CordovaPlugin {
                     });
 
                     break;
+                }
+                case "crashNow": {
+                    final String message = args.getString(0);
+                    if(message.isEmpty()) {
+                        NewRelic.crashNow();
+                    } else {
+                        NewRelic.crashNow(message);
+                    }
+                    break;
+                }
+                case "currentSessionId": {
+                    String sessionId = NewRelic.currentSessionId();
+                    callbackContext.success(sessionId);
+                    break;
+                }
+                case "incrementAttribute": {
+                    final String name = args.getString(0);
+                    final double value = args.getDouble(1);
+                    NewRelic.incrementAttribute(name, value);
+                    break;
+                }
+                case "noticeNetworkFailure": {
+                    final String url = args.getString(0);
+                    final String httpMethod = args.getString(1);
+                    final long startTime = args.getLong(2);
+                    final long endTime = args.getLong(3);
+                    final String failure = args.getString(4);
+
+                    Map<String, NetworkFailure> strToNetworkFailure = new HashMap<>();
+                    strToNetworkFailure.put("Unknown", NetworkFailure.Unknown);
+                    strToNetworkFailure.put("BadURL", NetworkFailure.BadURL);
+                    strToNetworkFailure.put("TimedOut", NetworkFailure.TimedOut);
+                    strToNetworkFailure.put("CannotConnectToHost", NetworkFailure.CannotConnectToHost);
+                    strToNetworkFailure.put("DNSLookupFailed", NetworkFailure.DNSLookupFailed);
+                    strToNetworkFailure.put("BadServerResponse", NetworkFailure.BadServerResponse);
+                    strToNetworkFailure.put("SecureConnectionFailed", NetworkFailure.SecureConnectionFailed);
+
+                    NewRelic.noticeNetworkFailure(url, httpMethod, startTime, endTime, strToNetworkFailure.get(failure));
+                    break;
+                }
+                case "recordMetric": {
+                    final String name = args.getString(0);
+                    final String category = args.getString(1);
+                    final double value = args.getDouble(2);
+                    final String metricUnit = args.getString(3);
+                    final String valueUnit = args.getString(4);
+
+                    Map<String, MetricUnit> strToMetricUnit = new HashMap<>();
+                    strToMetricUnit.put("PERCENT", MetricUnit.PERCENT);
+                    strToMetricUnit.put("BYTES", MetricUnit.BYTES);
+                    strToMetricUnit.put("SECONDS", MetricUnit.SECONDS);
+                    strToMetricUnit.put("BYTES_PER_SECOND", MetricUnit.BYTES_PER_SECOND);
+                    strToMetricUnit.put("OPERATIONS", MetricUnit.OPERATIONS);
+
+                    if (value < 0) {
+                        NewRelic.recordMetric(name, category);
+                    } else {
+                        if (metricUnit == null || valueUnit == null || metricUnit.equals("null") || valueUnit.equals("null")) {
+                            NewRelic.recordMetric(name, category, value);
+                        } else {
+                            NewRelic.recordMetric(name, category, 1, value, value, strToMetricUnit.get(metricUnit), strToMetricUnit.get(valueUnit));
+                        }
+                    }
+
+                    break;
+                }
+                case "removeAllAttributes": {
+                    NewRelic.removeAllAttributes();
+                    break;
+                }
+                case "setMaxEventBufferTime": {
+                    final int maxEventBufferTimeInSeconds = args.getInt(0);
+                    NewRelic.setMaxEventBufferTime(maxEventBufferTimeInSeconds);
+                    break;
+                }
+                case "setMaxEventPoolSize": {
+                    final int maxPoolSize = args.getInt(0);
+                    NewRelic.setMaxEventPoolSize(maxPoolSize);
+                    break;
+                }
+                // case "analyticsEventEnabled": {
+                //     final boolean enabled = args.getBoolean(0);
+                //     if(enabled) {
+                //         NewRelic.enableFeature(FeatureFlag.AnalyticsEvents);
+                //     } else {
+                //         NewRelic.disableFeature(FeatureFlag.AnalyticsEvents);
+                //     }
+                //     break;
+                // }
+                // case "networkRequestEnabled": {
+                //     final boolean enabled = args.getBoolean(0);
+                //     if(enabled) {
+                //         NewRelic.enableFeature(FeatureFlag.NetworkRequests);
+                //     } else {
+                //         NewRelic.disableFeature(FeatureFlag.NetworkRequests);
+                //     }
+                //     break;
+                // }
+                // case "networkErrorRequestEnabled": {
+                //     final boolean enabled = args.getBoolean(0);
+                //     if(enabled) {
+                //         NewRelic.enableFeature(FeatureFlag.NetworkErrorRequests);
+                //     } else {
+                //         NewRelic.disableFeature(FeatureFlag.NetworkErrorRequests);
+                //     }
+                //     break;
+                // }
+                // case "httpRequestBodyCaptureEnabled": {
+                //     final boolean enabled = args.getBoolean(0);
+                //     if(enabled) {
+                //         NewRelic.enableFeature(FeatureFlag.HttpResponseBodyCapture);
+                //     } else {
+                //         NewRelic.disableFeature(FeatureFlag.HttpResponseBodyCapture);
+                //     }
+                //     break;
+                // }
+                
             }
         } catch (Exception e) {
             NewRelic.recordHandledException(e);

--- a/src/android/NewRelicCordovaPlugin.java
+++ b/src/android/NewRelicCordovaPlugin.java
@@ -137,8 +137,8 @@ public class NewRelicCordovaPlugin extends CordovaPlugin {
                                     errorStack.length() > 4095 ? errorStack.substring(0, 4094) : errorStack);
                         }
 
-                        NewRelic.recordBreadcrumb("Mobile JS Errors", crashEvents);
-                        NewRelic.recordCustomEvent("Mobile JS Errors", "", crashEvents);
+                        NewRelic.recordBreadcrumb("JS Errors", crashEvents);
+                        NewRelic.recordCustomEvent("JS Errors", "", crashEvents);
 
                         StatsEngine.get().inc("Supportability/Mobile/Cordova/JSError");
 

--- a/src/ios/NewRelicCordovaPlugin.h
+++ b/src/ios/NewRelicCordovaPlugin.h
@@ -52,12 +52,12 @@
 
 - (void)setMaxEventPoolSize:(CDVInvokedUrlCommand *)command;
 
-// - (void)analyticsEventEnabled:(CDVInvokedUrlCommand *) command;
+- (void)analyticsEventEnabled:(CDVInvokedUrlCommand *) command;
 
-// - (void)networkRequestEnabled:(CDVInvokedUrlCommand *) command;
+- (void)networkRequestEnabled:(CDVInvokedUrlCommand *) command;
 
-// - (void)networkErrorRequestEnabled:(CDVInvokedUrlCommand *) command;
+- (void)networkErrorRequestEnabled:(CDVInvokedUrlCommand *) command;
 
-// - (void)httpRequestBodyCaptureEnabled:(CDVInvokedUrlCommand *) command;
+- (void)httpRequestBodyCaptureEnabled:(CDVInvokedUrlCommand *) command;
 
 @end

--- a/src/ios/NewRelicCordovaPlugin.h
+++ b/src/ios/NewRelicCordovaPlugin.h
@@ -36,5 +36,28 @@
 
 - (void)recordError:(CDVInvokedUrlCommand *)command;
 
+- (void)crashNow:(CDVInvokedUrlCommand *)command;
+
+- (void)currentSessionId:(CDVInvokedUrlCommand *)command;
+
+- (void)incrementAttribute:(CDVInvokedUrlCommand *)command;
+
+- (void)noticeNetworkFailure:(CDVInvokedUrlCommand *)command;
+
+- (void)recordMetric:(CDVInvokedUrlCommand *)command;
+
+- (void)removeAllAttributes:(CDVInvokedUrlCommand *)command;
+
+- (void)setMaxEventBufferTime:(CDVInvokedUrlCommand *)command;
+
+- (void)setMaxEventPoolSize:(CDVInvokedUrlCommand *)command;
+
+// - (void)analyticsEventEnabled:(CDVInvokedUrlCommand *) command;
+
+// - (void)networkRequestEnabled:(CDVInvokedUrlCommand *) command;
+
+// - (void)networkErrorRequestEnabled:(CDVInvokedUrlCommand *) command;
+
+// - (void)httpRequestBodyCaptureEnabled:(CDVInvokedUrlCommand *) command;
 
 @end

--- a/src/ios/NewRelicCordovaPlugin.m
+++ b/src/ios/NewRelicCordovaPlugin.m
@@ -208,33 +208,33 @@
     [NewRelic setMaxEventPoolSize:uint_maxPoolSize];
 }
 
-// - (void)analyticsEventEnabled:(CDVInvokedUrlCommand *)command {
-//     // This should only be an android method call, so we do nothing here.
-//     return;
-// }
+- (void)analyticsEventEnabled:(CDVInvokedUrlCommand *)command {
+    // This should only be an android method call, so we do nothing here.
+    return;
+}
 
-// - (void)networkRequestEnabled:(CDVInvokedUrlCommand *)command {
-//     if([[command.arguments objectAtIndex:0] boolValue] == YES) {
-//         [NewRelic enableFeatures:NRFeatureFlag_NetworkRequestEvents];
-//     } else {
-//         [NewRelic disableFeatures:NRFeatureFlag_NetworkRequestEvents];
-//     }
-// }
+- (void)networkRequestEnabled:(CDVInvokedUrlCommand *)command {
+    if([[command.arguments objectAtIndex:0] boolValue] == YES) {
+        [NewRelic enableFeatures:NRFeatureFlag_NetworkRequestEvents];
+    } else {
+        [NewRelic disableFeatures:NRFeatureFlag_NetworkRequestEvents];
+    }
+}
 
-// - (void)networkErrorRequestEnabled:(CDVInvokedUrlCommand *)command {
-//     if([[command.arguments objectAtIndex:0] boolValue] == YES) {
-//         [NewRelic enableFeatures:NRFeatureFlag_RequestErrorEvents];
-//     } else {
-//         [NewRelic disableFeatures:NRFeatureFlag_RequestErrorEvents];
-//     }
-// }
+- (void)networkErrorRequestEnabled:(CDVInvokedUrlCommand *)command {
+    if([[command.arguments objectAtIndex:0] boolValue] == YES) {
+        [NewRelic enableFeatures:NRFeatureFlag_RequestErrorEvents];
+    } else {
+        [NewRelic disableFeatures:NRFeatureFlag_RequestErrorEvents];
+    }
+}
 
-// - (void)httpRequestBodyCaptureEnabled:(CDVInvokedUrlCommand *)command {
-//     if([[command.arguments objectAtIndex:0] boolValue] == YES) {
-//         [NewRelic enableFeatures:NRFeatureFlag_HttpResponseBodyCapture];
-//     } else {
-//         [NewRelic disableFeatures:NRFeatureFlag_HttpResponseBodyCapture];
-//     }
+- (void)httpRequestBodyCaptureEnabled:(CDVInvokedUrlCommand *)command {
+    if([[command.arguments objectAtIndex:0] boolValue] == YES) {
+        [NewRelic enableFeatures:NRFeatureFlag_HttpResponseBodyCapture];
+    } else {
+        [NewRelic disableFeatures:NRFeatureFlag_HttpResponseBodyCapture];
+    }
 }
 
 @end

--- a/src/ios/NewRelicCordovaPlugin.m
+++ b/src/ios/NewRelicCordovaPlugin.m
@@ -123,4 +123,118 @@
    [NewRelic noticeNetworkRequestForURL:nsurl httpMethod:method startTime:[startTime doubleValue] endTime:[endTime doubleValue] responseHeaders:nil statusCode:(long)[status integerValue] bytesSent:(long)[bytesSent integerValue] bytesReceived:(long)[bytesreceived integerValue] responseData:data traceHeaders:nil andParams:nil];
 }
 
+- (void)crashNow:(CDVInvokedUrlCommand *)command {
+    NSString* message = [command.arguments objectAtIndex:0];
+    if ([message length] == 0) {
+        [NewRelic crashNow];
+    } else {
+        [NewRelic crashNow:message];
+    }
+}
+
+- (void)currentSessionId:(CDVInvokedUrlCommand *)command {
+    NSString* sessionId = [NewRelic currentSessionId];
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:sessionId];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void)incrementAttribute:(CDVInvokedUrlCommand *)command {
+    NSString* name = [command.arguments objectAtIndex:0];
+    NSNumber* value = [command.arguments objectAtIndex:1];
+    [NewRelic incrementAttribute:name value:value];
+}
+
+- (void)noticeNetworkFailure:(CDVInvokedUrlCommand *)command {
+    NSString* url = [command.arguments objectAtIndex:0];
+    NSString* httpMethod = [command.arguments objectAtIndex:1];
+    NSNumber* startTime = [command.arguments objectAtIndex:2];
+    NSNumber* endTime = [command.arguments objectAtIndex:3];
+    NSString* failure = [command.arguments objectAtIndex:4];
+    
+    NSURL *nsurl = [NSURL URLWithString:url];
+    
+    NSDictionary *dict = @{
+            @"Unknown": [NSNumber numberWithInt:NRURLErrorUnknown],
+            @"BadURL": [NSNumber numberWithInt:NRURLErrorBadURL],
+            @"TimedOut": [NSNumber numberWithInt:NRURLErrorTimedOut],
+            @"CannotConnectToHost": [NSNumber numberWithInt:NRURLErrorCannotConnectToHost],
+            @"DNSLookupFailed": [NSNumber numberWithInt:NRURLErrorDNSLookupFailed],
+            @"BadServerResponse": [NSNumber numberWithInt:NRURLErrorBadServerResponse],
+            @"SecureConnectionFailed": [NSNumber numberWithInt:NRURLErrorSecureConnectionFailed],
+        };
+    NSInteger iOSFailureCode = [[dict valueForKey:failure] integerValue];
+    [NewRelic noticeNetworkFailureForURL:nsurl httpMethod:httpMethod startTime:[startTime doubleValue] endTime:[endTime doubleValue] andFailureCode:iOSFailureCode];
+}
+
+- (void)recordMetric:(CDVInvokedUrlCommand *)command {
+    NSString* name = [command.arguments objectAtIndex:0];
+    NSString* category = [command.arguments objectAtIndex:1];
+    NSNumber* value = [command.arguments objectAtIndex:2];
+    NSString* countUnit = [command.arguments objectAtIndex:3];
+    NSString* valueUnit = [command.arguments objectAtIndex:4];
+    
+    NSDictionary *dict = @{
+        @"PERCENT": kNRMetricUnitPercent,
+        @"BYTES": kNRMetricUnitBytes,
+        @"SECONDS": kNRMetricUnitSeconds,
+        @"BYTES_PER_SECOND": kNRMetricUnitsBytesPerSecond,
+        @"OPERATIONS": kNRMetricUnitsOperations
+    };
+    
+    if (value < 0) {
+        [NewRelic recordMetricWithName:name category:category];
+    } else {
+        if (countUnit == nil || valueUnit == nil) {
+            [NewRelic recordMetricWithName:name category:category value:value];
+        } else {
+            [NewRelic recordMetricWithName:name category:category value:value valueUnits:dict[valueUnit] countUnits:dict[countUnit]];
+        }
+    }
+}
+
+- (void)removeAllAttributes:(CDVInvokedUrlCommand *)command {
+    [NewRelic removeAllAttributes];
+}
+
+- (void)setMaxEventBufferTime:(CDVInvokedUrlCommand *)command {
+    NSNumber* maxBufferTimeInSeconds = [command.arguments objectAtIndex:0];
+    unsigned int uint_seconds = maxBufferTimeInSeconds.unsignedIntValue;
+    [NewRelic setMaxEventBufferTime:uint_seconds];
+}
+
+- (void)setMaxEventPoolSize:(CDVInvokedUrlCommand *)command {
+    NSNumber* maxPoolSize = [command.arguments objectAtIndex:0];
+    unsigned int uint_maxPoolSize = maxPoolSize.unsignedIntValue;
+    [NewRelic setMaxEventPoolSize:uint_maxPoolSize];
+}
+
+// - (void)analyticsEventEnabled:(CDVInvokedUrlCommand *)command {
+//     // This should only be an android method call, so we do nothing here.
+//     return;
+// }
+
+// - (void)networkRequestEnabled:(CDVInvokedUrlCommand *)command {
+//     if([[command.arguments objectAtIndex:0] boolValue] == YES) {
+//         [NewRelic enableFeatures:NRFeatureFlag_NetworkRequestEvents];
+//     } else {
+//         [NewRelic disableFeatures:NRFeatureFlag_NetworkRequestEvents];
+//     }
+// }
+
+// - (void)networkErrorRequestEnabled:(CDVInvokedUrlCommand *)command {
+//     if([[command.arguments objectAtIndex:0] boolValue] == YES) {
+//         [NewRelic enableFeatures:NRFeatureFlag_RequestErrorEvents];
+//     } else {
+//         [NewRelic disableFeatures:NRFeatureFlag_RequestErrorEvents];
+//     }
+// }
+
+// - (void)httpRequestBodyCaptureEnabled:(CDVInvokedUrlCommand *)command {
+//     if([[command.arguments objectAtIndex:0] boolValue] == YES) {
+//         [NewRelic enableFeatures:NRFeatureFlag_HttpResponseBodyCapture];
+//     } else {
+//         [NewRelic disableFeatures:NRFeatureFlag_HttpResponseBodyCapture];
+//     }
+}
+
 @end

--- a/www/js/newrelic.js
+++ b/www/js/newrelic.js
@@ -235,45 +235,44 @@ var NewRelic = {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "setMaxEventPoolSize", [maxPoolSize]);
     },
 
+    /**
+     * FOR ANDROID ONLY.
+     * Enable or disable collection of event data.
+     * @param {boolean} enabled Boolean value for enabling analytics events.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
+    analyticsEventEnabled: function(enabled, cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "analyticsEventEnabled", [enabled]);
+    },
 
-    // /**
-    //  * FOR ANDROID ONLY.
-    //  * Enable or disable collection of event data.
-    //  * @param {boolean} enabled Boolean value for enabling analytics events.
-    //  * @param {function} cb A success callback function.
-    //  * @param {function} fail An error callback function.
-    //  */
-    // analyticsEventEnabled: function(enabled, cb, fail) {
-    //     cordova.exec(cb, fail, "NewRelicCordovaPlugin", "analyticsEventEnabled", [enabled]);
-    // },
+    /**
+     * Enable or disable reporting sucessful HTTP request to the MobileRequest event type.
+     * @param {boolean} enabled Boolean value for enable successful HTTP requests.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
+    networkRequestEnabled: function(enabled, cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "networkRequestEnabled", [enabled]);
+    },
 
-    // /**
-    //  * Enable or disable reporting sucessful HTTP request to the MobileRequest event type.
-    //  * @param {boolean} enabled Boolean value for enable successful HTTP requests.
-    //  * @param {function} cb A success callback function.
-    //  * @param {function} fail An error callback function.
-    //  */
-    // networkRequestEnabled: function(enabled, cb, fail) {
-    //     cordova.exec(cb, fail, "NewRelicCordovaPlugin", "networkRequestEnabled", enabled);
-    // },
+    /**
+     * Enable or disable reporting network and HTTP request errors to the MobileRequestError event type.
+     * @param {boolean} enabled Boolean value for enabling network request errors.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
+    networkErrorRequestEnabled: function(enabled, cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "networkErrorRequestEnabled", [enabled]);
+    },
 
-    // /**
-    //  * Enable or disable reporting network and HTTP request errors to the MobileRequestError event type.
-    //  * @param {boolean} enabled Boolean value for enabling network request errors.
-    //  * @param {function} cb A success callback function.
-    //  * @param {function} fail An error callback function.
-    //  */
-    // networkErrorRequestEnabled: function(enabled, cb, fail) {
-    //     cordova.exec(cb, fail, "NewRelicCordovaPlugin", "networkErrorRequestEnabled", [enabled]);
-    // },
-
-    // /**
-    //  * Enable or disable capture of HTTP response bodies for HTTP error traces, and MobileRequestError events.
-    //  * @param {boolean} enabled Boolean value for enabling HTTP response bodies. 
-    //  */
-    // httpRequestBodyCaptureEnabled: function(enabled, cb, fail) {
-    //     cordova.exec(cb, fail, "NewRelicCordovaPlugin", "httpRequestBodyCaptureEnabled", [enabled]);
-    // }
+    /**
+     * Enable or disable capture of HTTP response bodies for HTTP error traces, and MobileRequestError events.
+     * @param {boolean} enabled Boolean value for enabling HTTP response bodies. 
+     */
+    httpRequestBodyCaptureEnabled: function(enabled, cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "httpRequestBodyCaptureEnabled", [enabled]);
+    },
 
 }
 

--- a/www/js/newrelic.js
+++ b/www/js/newrelic.js
@@ -1,26 +1,71 @@
 var exec = require("cordova/exec");
 
 var NewRelic = {
+
+    /**
+     * 
+     * @param {string} url The URL of the request.
+     * @param {string} method The HTTP method used, such as GET or POST.
+     * @param {number} status The statusCode of the HTTP response, such as 200 for OK.
+     * @param {number} startTime The start time of the request in milliseconds since the epoch.
+     * @param {number} endTime The end time of the request in milliseconds since the epoch.
+     * @param {number} bytesSent The number of bytes sent in the request.
+     * @param {number} bytesreceived The number of bytes received in the response.
+     * @param {string} body Optional. The response body of the HTTP response. The response body will be truncated and included in an HTTP Error metric if the HTTP transaction is an error.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
     noticeHttpTransaction: function (url, method, status, startTime, endTime, bytesSent, bytesreceived, body, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "noticeHttpTransaction", [url, method, status, startTime, endTime, bytesSent, bytesreceived, body]);
     },
 
+    //
     noticeDistributedTrace: function (cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "noticeDistributedTrace");
     },
-
+    
+    /**
+     * Sets a custom user identifier value to associate mobile user
+     * @param {string} userId The user identifier string.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
     setUserId: function (userId, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "setUserId", [userId]);
     },
 
+    /**
+     * Creates a custom attribute with a specified name and value.
+     * When called, it overwrites its previous value and type.
+     * The created attribute is shared by multiple Mobile event types.
+     * @param {string} name Name of the attribute.
+     * @param {number} value Value of the attribute.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
     setAttribute: function (name, value, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "setAttribute", [name, value]);
     },
 
+    /**
+     * Remove a custom attribute with a specified name and value.
+     * When called, it removes the attribute specified by the name string.
+     * The removed attribute is shared by multiple Mobile event types.
+     * @param {string} name Name of the attribute. 
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
     removeAttribute: function (name, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "removeAttribute", [name, value]);
     },
 
+    /**
+     * Creates and records a MobileBreadcrumb event.
+     * @param {string} name The name you want to give to a breadcrumb event.
+     * @param {Map<string, string|number>} eventAttributes A map that includes a list of attributes.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
     recordBreadcrumb: function (name, eventAttributes, cb, fail) {
         if (eventAttributes === undefined) {
             eventAttributes = {}
@@ -28,19 +73,42 @@ var NewRelic = {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordBreadCrumb", [name, eventAttributes]);
     },
 
+    /**
+     * Creates and records a custom event, for use in New Relic Insights.
+     * The event includes a list of attributes, specified as a map.
+     * @param {string} eventType The type of event.
+     * @param {string} eventName The name of the event.
+     * @param {Map<string, string|number>} attributes A map that includes a list of attributes.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
     recordCustomEvent: function (eventType, eventName, attributes, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordCustomEvent", [eventType, eventName, attributes]);
     },
 
+    /**
+     * Track a method as an interaction.
+     * @param {string} actionName The name of the action.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     * @returns 
+     */
     startInteraction: function (actionName, cb, fail) {
         return new Promise(function(cb, fail) {
             cordova.exec(cb, fail, "NewRelicCordovaPlugin", "startInteraction", [actionName]);
         });
     },
 
+    /**
+     * End an interaction
+     * @param {string} interactionId The string ID for the interaction you want to end. This string is returned when you use startInteraction().
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
     endInteraction: function (interactionId, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "endInteraction", [interactionId]);
     },
+
     sendConsole(type, args) {
         const argsStr = JSON.stringify(args);
         this.send('MobileJSConsole', { consoleType: type, args: argsStr });
@@ -55,14 +123,161 @@ var NewRelic = {
 
         this.recordCustomEvent("consoleEvents", name, args);
     },
+
+    /**
+     * Records JavaScript errors for cordova.
+     * @param {string} name The name of the error.
+     * @param {string} message The message of the error.
+     * @param {string} stack The error stack of the error.
+     * @param {boolean} isFatal The flag for whether the error is fatal.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
     recordError(name, message, stack, isFatal, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordError", [name, message, stack, isFatal]);
-    }
+    },
 
+    /**
+     * Throws a demo run-time exception to test New Relic crash reporting.
+     * @param {string} message An optional argument attached to the exception.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
+    crashNow: function(message='', cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "crashNow", [message]);
+    },
+
+    /**
+     * Returns the current session ID as a parameter to the successful callback function.
+     * This method is useful for consolidating monitoring of app data (not just New Relic data) based on a single session definition and identifier.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
+    currentSessionId: function(cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "currentSessionId");
+    },
+
+    /**
+     * Increments the count of an attribute with a specified name.
+     * When called, it overwrites its previous value and type each time.
+     * If attribute does not exist, it creates an attribute with a value of 1.
+     * The incremented attribute is shared by multiple Mobile event types.
+     * @param {string} name The name of the attribute.
+     * @param {number} value Optional argument that increments the attribute by this value.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
+    incrementAttribute: function(name, value=1, cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "incrementAttribute", [name, value]);
+    },
+
+    /**
+     * Records network failures.
+     * If a network request fails, use this method to record details about the failure.
+     * In most cases, place this call inside exception handlers.
+     * @param {string} url The URL of the request.
+     * @param {string} httpMethod The HTTP method used, such as GET or POST.
+     * @param {number} startTime The start time of the request in milliseconds since the epoch.
+     * @param {number} endTime The end time of the request in milliseconds since the epoch.
+     * @param {string} failure The name of the network failure. Possible values are 'Unknown', 'BadURL', 'TimedOut', 'CannotConnectToHost', 'DNSLookupFailed', 'BadServerResponse', 'SecureConnectionFailed'.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
+    noticeNetworkFailure: function(url, httpMethod, startTime, endTime, failure, cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "noticeNetworkFailure", [url, httpMethod, startTime, endTime, failure]);
+    },
+
+    /**
+     * 
+     * @param {string} name The name for the custom metric.
+     * @param {string} category The metric category name.
+     * @param {number} value Optional. The value of the metric. Value should be a non-zero positive number.
+     * @param {string} countUnit Optional (but requires value and valueUnit to be set). Unit of measurement for the metric count. Supported values are 'PERCENT', 'BYTES', 'SECONDS', 'BYTES_PER_SECOND', or 'OPERATIONS'.
+     * @param {string} valueUnit Optional (but requires value and countUnit to be set). Unit of measurement for the metric value. Supported values are 'PERCENT', 'BYTES', 'SECONDS', 'BYTES_PER_SECOND', or 'OPERATIONS'. 
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
+    recordMetric: function(name, category, value=-1, countUnit=null, valueUnit=null, cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordMetric", [name, category, value, countUnit, valueUnit]);
+    },
+
+    /**
+     * Removes all attributes from the session.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
+    removeAllAttributes: function(cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "removeAllAttributes");
+    },
+
+    /**
+     * Sets the event harvest cycle length.
+     * Default is 600 seconds (10 minutes).
+     * Minimum value cannot be less than 60 seconds.
+     * Maximum value should not be greater than 600 seconds.
+     * @param {number} maxBufferTimeInSeconds The maximum time (in seconds) that the agent should store events in memory.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
+    setMaxEventBufferTime: function(maxBufferTimeInSeconds, cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "setMaxEventBufferTime", [maxBufferTimeInSeconds]);
+    },
+
+    /**
+     * Sets the maximum size of the event pool stored in memory until the next harvest cycle.
+     * When the pool size limit is reached, the agent will start sampling events, discarding some new and old, until the pool of events is sent in the next harvest cycle.
+     * Default is a maximum of 1000 events per event harvest cycle.
+     * @param {number} maxPoolSize The maximum number of events per harvest cycle.
+     * @param {function} cb A success callback function.
+     * @param {function} fail An error callback function.
+     */
+    setMaxEventPoolSize: function(maxPoolSize, cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "setMaxEventPoolSize", [maxPoolSize]);
+    },
+
+
+    // /**
+    //  * FOR ANDROID ONLY.
+    //  * Enable or disable collection of event data.
+    //  * @param {boolean} enabled Boolean value for enabling analytics events.
+    //  * @param {function} cb A success callback function.
+    //  * @param {function} fail An error callback function.
+    //  */
+    // analyticsEventEnabled: function(enabled, cb, fail) {
+    //     cordova.exec(cb, fail, "NewRelicCordovaPlugin", "analyticsEventEnabled", [enabled]);
+    // },
+
+    // /**
+    //  * Enable or disable reporting sucessful HTTP request to the MobileRequest event type.
+    //  * @param {boolean} enabled Boolean value for enable successful HTTP requests.
+    //  * @param {function} cb A success callback function.
+    //  * @param {function} fail An error callback function.
+    //  */
+    // networkRequestEnabled: function(enabled, cb, fail) {
+    //     cordova.exec(cb, fail, "NewRelicCordovaPlugin", "networkRequestEnabled", enabled);
+    // },
+
+    // /**
+    //  * Enable or disable reporting network and HTTP request errors to the MobileRequestError event type.
+    //  * @param {boolean} enabled Boolean value for enabling network request errors.
+    //  * @param {function} cb A success callback function.
+    //  * @param {function} fail An error callback function.
+    //  */
+    // networkErrorRequestEnabled: function(enabled, cb, fail) {
+    //     cordova.exec(cb, fail, "NewRelicCordovaPlugin", "networkErrorRequestEnabled", [enabled]);
+    // },
+
+    // /**
+    //  * Enable or disable capture of HTTP response bodies for HTTP error traces, and MobileRequestError events.
+    //  * @param {boolean} enabled Boolean value for enabling HTTP response bodies. 
+    //  */
+    // httpRequestBodyCaptureEnabled: function(enabled, cb, fail) {
+    //     cordova.exec(cb, fail, "NewRelicCordovaPlugin", "httpRequestBodyCaptureEnabled", [enabled]);
+    // }
 
 }
 
-netwoekRequest = {};
+networkRequest = {};
 window.XMLHttpRequest.prototype.open = function (method, url) {
     // Keep track of the method and url
     // start time is tracked by the `send` method
@@ -70,10 +285,10 @@ window.XMLHttpRequest.prototype.open = function (method, url) {
     // eslint-disable-next-line prefer-rest-params
     console.log("nis" + method);
     console.log(url);
-    netwoekRequest.url = url;
-    netwoekRequest.method = method;
-    netwoekRequest.bytesSent = 0;
-    netwoekRequest.startTime = Date.now();
+    networkRequest.url = url;
+    networkRequest.method = method;
+    networkRequest.bytesSent = 0;
+    networkRequest.startTime = Date.now();
     return originalXhrOpen.apply(this, arguments)
 
 }
@@ -115,10 +330,10 @@ window.XMLHttpRequest.prototype.send = function (data) {
                 }
                 if (this.readyState === this.DONE) {
                     console.log("3" + this.status);
-                    netwoekRequest.endTime = Date.now();
-                    netwoekRequest.status = this.status;
-                    netwoekRequest.bytesreceived = this.responseText.length;
-                    netwoekRequest.body = this.responseText;
+                    networkRequest.endTime = Date.now();
+                    networkRequest.status = this.status;
+                    networkRequest.bytesreceived = this.responseText.length;
+                    networkRequest.body = this.responseText;
 
                     if (this.response) {
                         if (this.responseType === 'blob') {
@@ -130,7 +345,7 @@ window.XMLHttpRequest.prototype.send = function (data) {
                             console.log("3" + this.response);
                         }
 
-                        NewRelic.noticeHttpTransaction(netwoekRequest.url, netwoekRequest.method, netwoekRequest.status, netwoekRequest.startTime, netwoekRequest.endTime, netwoekRequest.bytesSent, netwoekRequest.bytesreceived, netwoekRequest.body);
+                        NewRelic.noticeHttpTransaction(networkRequest.url, networkRequest.method, networkRequest.status, networkRequest.startTime, networkRequest.endTime, networkRequest.bytesSent, networkRequest.bytesreceived, networkRequest.body);
 
                     }
 

--- a/www/js/newrelic.js
+++ b/www/js/newrelic.js
@@ -10,16 +10,13 @@ var NewRelic = {
      * @param {number} startTime The start time of the request in milliseconds since the epoch.
      * @param {number} endTime The end time of the request in milliseconds since the epoch.
      * @param {number} bytesSent The number of bytes sent in the request.
-     * @param {number} bytesreceived The number of bytes received in the response.
+     * @param {number} bytesReceived The number of bytes received in the response.
      * @param {string} body Optional. The response body of the HTTP response. The response body will be truncated and included in an HTTP Error metric if the HTTP transaction is an error.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
-    noticeHttpTransaction: function (url, method, status, startTime, endTime, bytesSent, bytesreceived, body, cb, fail) {
-        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "noticeHttpTransaction", [url, method, status, startTime, endTime, bytesSent, bytesreceived, body]);
+    noticeHttpTransaction: function (url, method, status, startTime, endTime, bytesSent, bytesReceived, body, cb, fail) {
+        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "noticeHttpTransaction", [url, method, status, startTime, endTime, bytesSent, bytesReceived, body]);
     },
 
-    //
     noticeDistributedTrace: function (cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "noticeDistributedTrace");
     },
@@ -27,8 +24,6 @@ var NewRelic = {
     /**
      * Sets a custom user identifier value to associate mobile user
      * @param {string} userId The user identifier string.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     setUserId: function (userId, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "setUserId", [userId]);
@@ -40,8 +35,6 @@ var NewRelic = {
      * The created attribute is shared by multiple Mobile event types.
      * @param {string} name Name of the attribute.
      * @param {number} value Value of the attribute.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     setAttribute: function (name, value, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "setAttribute", [name, value]);
@@ -52,8 +45,6 @@ var NewRelic = {
      * When called, it removes the attribute specified by the name string.
      * The removed attribute is shared by multiple Mobile event types.
      * @param {string} name Name of the attribute. 
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     removeAttribute: function (name, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "removeAttribute", [name, value]);
@@ -63,8 +54,6 @@ var NewRelic = {
      * Creates and records a MobileBreadcrumb event.
      * @param {string} name The name you want to give to a breadcrumb event.
      * @param {Map<string, string|number>} eventAttributes A map that includes a list of attributes.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     recordBreadcrumb: function (name, eventAttributes, cb, fail) {
         if (eventAttributes === undefined) {
@@ -79,8 +68,6 @@ var NewRelic = {
      * @param {string} eventType The type of event.
      * @param {string} eventName The name of the event.
      * @param {Map<string, string|number>} attributes A map that includes a list of attributes.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     recordCustomEvent: function (eventType, eventName, attributes, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordCustomEvent", [eventType, eventName, attributes]);
@@ -90,8 +77,7 @@ var NewRelic = {
      * Track a method as an interaction.
      * @param {string} actionName The name of the action.
      * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
-     * @returns 
+     * @returns {Promise} A promise containing the interactionId.
      */
     startInteraction: function (actionName, cb, fail) {
         return new Promise(function(cb, fail) {
@@ -102,8 +88,6 @@ var NewRelic = {
     /**
      * End an interaction
      * @param {string} interactionId The string ID for the interaction you want to end. This string is returned when you use startInteraction().
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     endInteraction: function (interactionId, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "endInteraction", [interactionId]);
@@ -130,8 +114,6 @@ var NewRelic = {
      * @param {string} message The message of the error.
      * @param {string} stack The error stack of the error.
      * @param {boolean} isFatal The flag for whether the error is fatal.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     recordError(name, message, stack, isFatal, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordError", [name, message, stack, isFatal]);
@@ -140,8 +122,6 @@ var NewRelic = {
     /**
      * Throws a demo run-time exception to test New Relic crash reporting.
      * @param {string} message An optional argument attached to the exception.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     crashNow: function(message='', cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "crashNow", [message]);
@@ -151,10 +131,12 @@ var NewRelic = {
      * Returns the current session ID as a parameter to the successful callback function.
      * This method is useful for consolidating monitoring of app data (not just New Relic data) based on a single session definition and identifier.
      * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
+     * @returns {Promise} A promise containing the current session ID.
      */
     currentSessionId: function(cb, fail) {
-        cordova.exec(cb, fail, "NewRelicCordovaPlugin", "currentSessionId");
+        return new Promise(function(cb, fail) {
+            cordova.exec(cb, fail, "NewRelicCordovaPlugin", "currentSessionId");
+        });
     },
 
     /**
@@ -164,8 +146,6 @@ var NewRelic = {
      * The incremented attribute is shared by multiple Mobile event types.
      * @param {string} name The name of the attribute.
      * @param {number} value Optional argument that increments the attribute by this value.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     incrementAttribute: function(name, value=1, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "incrementAttribute", [name, value]);
@@ -180,8 +160,6 @@ var NewRelic = {
      * @param {number} startTime The start time of the request in milliseconds since the epoch.
      * @param {number} endTime The end time of the request in milliseconds since the epoch.
      * @param {string} failure The name of the network failure. Possible values are 'Unknown', 'BadURL', 'TimedOut', 'CannotConnectToHost', 'DNSLookupFailed', 'BadServerResponse', 'SecureConnectionFailed'.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     noticeNetworkFailure: function(url, httpMethod, startTime, endTime, failure, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "noticeNetworkFailure", [url, httpMethod, startTime, endTime, failure]);
@@ -194,17 +172,13 @@ var NewRelic = {
      * @param {number} value Optional. The value of the metric. Value should be a non-zero positive number.
      * @param {string} countUnit Optional (but requires value and valueUnit to be set). Unit of measurement for the metric count. Supported values are 'PERCENT', 'BYTES', 'SECONDS', 'BYTES_PER_SECOND', or 'OPERATIONS'.
      * @param {string} valueUnit Optional (but requires value and countUnit to be set). Unit of measurement for the metric value. Supported values are 'PERCENT', 'BYTES', 'SECONDS', 'BYTES_PER_SECOND', or 'OPERATIONS'. 
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     recordMetric: function(name, category, value=-1, countUnit=null, valueUnit=null, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordMetric", [name, category, value, countUnit, valueUnit]);
     },
 
     /**
-     * Removes all attributes from the session.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
+     * Removes all attributes from the session..
      */
     removeAllAttributes: function(cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "removeAllAttributes");
@@ -216,8 +190,6 @@ var NewRelic = {
      * Minimum value cannot be less than 60 seconds.
      * Maximum value should not be greater than 600 seconds.
      * @param {number} maxBufferTimeInSeconds The maximum time (in seconds) that the agent should store events in memory.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     setMaxEventBufferTime: function(maxBufferTimeInSeconds, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "setMaxEventBufferTime", [maxBufferTimeInSeconds]);
@@ -228,8 +200,6 @@ var NewRelic = {
      * When the pool size limit is reached, the agent will start sampling events, discarding some new and old, until the pool of events is sent in the next harvest cycle.
      * Default is a maximum of 1000 events per event harvest cycle.
      * @param {number} maxPoolSize The maximum number of events per harvest cycle.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     setMaxEventPoolSize: function(maxPoolSize, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "setMaxEventPoolSize", [maxPoolSize]);
@@ -239,8 +209,6 @@ var NewRelic = {
      * FOR ANDROID ONLY.
      * Enable or disable collection of event data.
      * @param {boolean} enabled Boolean value for enabling analytics events.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     analyticsEventEnabled: function(enabled, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "analyticsEventEnabled", [enabled]);
@@ -249,8 +217,6 @@ var NewRelic = {
     /**
      * Enable or disable reporting sucessful HTTP request to the MobileRequest event type.
      * @param {boolean} enabled Boolean value for enable successful HTTP requests.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     networkRequestEnabled: function(enabled, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "networkRequestEnabled", [enabled]);
@@ -259,8 +225,6 @@ var NewRelic = {
     /**
      * Enable or disable reporting network and HTTP request errors to the MobileRequestError event type.
      * @param {boolean} enabled Boolean value for enabling network request errors.
-     * @param {function} cb A success callback function.
-     * @param {function} fail An error callback function.
      */
     networkErrorRequestEnabled: function(enabled, cb, fail) {
         cordova.exec(cb, fail, "NewRelicCordovaPlugin", "networkErrorRequestEnabled", [enabled]);


### PR DESCRIPTION
Added missing static methods currently not available but present in our react-native agent v0.0.7.

Things still left to be done:
- Need to investigate why data (metrics, network failures, MobileRequest, MobileRequestError) on iOS is sent to `mobile-collector.newrelic.com` but not showing up in NR1. React-Native on iOS data shows up fine.