### PR TITLE
fix: Fix null errors in recordMetric from JS to ios plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ cordova plugin update
 # Usage
 See the examples below and for more detail see: [New Relic IOS SDK doc](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api) or [Android SDK](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api).
 
+### Javascript
+> Methods in our plugin in Cordova can be called by importing `NewRelic` from `plugins/newrelic-cordova-plugin/www/js` or by using `window.NewRelic`.
+### Typescript
+> In TypeScript, you'll have to define our plugin before using it: `declare const NewRelic: any;`
+
 ### [noticeHttpTransaction](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/notice-http-transaction)(url: string, method: string, status: number, startTime: number, endTime: number, bytesSent: number, bytesReceived: number, body?: string)
 > The New Relic Cordova plugin automatically collects HTTP transactions, but if you want to manually record HTTP transactions, use this method to do so.
   ```js

--- a/src/ios/NewRelicCordovaPlugin.m
+++ b/src/ios/NewRelicCordovaPlugin.m
@@ -173,6 +173,8 @@
     NSString* countUnit = [command.arguments objectAtIndex:3];
     NSString* valueUnit = [command.arguments objectAtIndex:4];
     
+    int intval = (value.intValue);
+    
     NSDictionary *dict = @{
         @"PERCENT": kNRMetricUnitPercent,
         @"BYTES": kNRMetricUnitBytes,
@@ -181,10 +183,11 @@
         @"OPERATIONS": kNRMetricUnitsOperations
     };
     
-    if (value < 0) {
+    if (intval < 0) {
         [NewRelic recordMetricWithName:name category:category];
     } else {
-        if (countUnit == nil || valueUnit == nil) {
+        
+        if (countUnit == nil || valueUnit == nil || [countUnit isKindOfClass:[NSNull class]] || [valueUnit isKindOfClass:[NSNull class]]) {
             [NewRelic recordMetricWithName:name category:category value:value];
         } else {
             [NewRelic recordMetricWithName:name category:category value:value valueUnits:dict[valueUnit] countUnits:dict[countUnit]];


### PR DESCRIPTION
- Fixes null error in iOS plugin that would call the wrong overloaded function for recordMetric. 
- Added some instructions for using the plugin in JS and TS.