### PR TITLE
docs: Update README for recording errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ By default, these configurations are already set to true on agent start.
 ```
 
 ## Error Reporting
-### recordError(err: [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error), isFatal: boolean) : void;
+### recordError(err: [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)) : void;
 Records JavaScript errors for Cordova. It is useful to add this method by adding it to the error handler of the framework that you are using. Here are some examples below:
 
 ### Angular
@@ -213,7 +213,7 @@ export class GlobalErrorHandler extends ErrorHandler {
     super();
   }
   handleError(error: any): void {
-    NewRelic.recordError(error, false);
+    NewRelic.recordError(error);
     super.handleError(error);
   }
 }
@@ -242,7 +242,7 @@ export class ErrorBoundary extends Component {
             console.log(errorInfo.componentStack);
         }
 
-        NewRelic.recordError(error, false);
+        NewRelic.recordError(error);
         this.setState({ error });
     }
 
@@ -269,7 +269,7 @@ const NewRelicLogger = store => next => action => {
         NewRelic.recordBreadcrumb("NewRelicLogger error", store.getState());
 
         // Record the JS error to New Relic
-        NewRelic.recordError(err, false);
+        NewRelic.recordError(err);
     }
 }
 
@@ -306,7 +306,7 @@ Vue.config.errorHandler = (err, vm, info) => {
     NewRelic.recordBreadcrumb("Vue Error", { 'componentName': vm.$options.name, 'lifecycleHook': lifecycleHookInfo })
 
     // Record the JS error to New Relic
-    NewRelic.recordError(error, false);
+    NewRelic.recordError(error);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ By default, these configurations are already set to true on agent start.
 ```
 
 ## Error Reporting
+### recordError(err: [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error), isFatal: boolean) : void;
+Records JavaScript errors for Cordova. It is useful to add this method by adding it to the error handler of the framework that you are using. Here are some examples below:
 
 ### Angular
 Angular 2+ exposes an [ErrorHandler](https://angular.io/api/core/ErrorHandler) class to handle errors. You can implement New Relic by extending this class as follows:
@@ -204,13 +206,14 @@ Angular 2+ exposes an [ErrorHandler](https://angular.io/api/core/ErrorHandler) c
 ```ts
 import { ErrorHandler, Injectable } from '@angular/core';
 import { NewRelic } from "@awesome-cordova-plugins/newrelic";
+
 @Injectable()
 export class GlobalErrorHandler extends ErrorHandler {
   constructor() {
     super();
   }
   handleError(error: any): void {
-    NewRelic.recordError(error.name, error.message, error.stack, false);
+    NewRelic.recordError(error, false);
     super.handleError(error);
   }
 }
@@ -239,7 +242,7 @@ export class ErrorBoundary extends Component {
             console.log(errorInfo.componentStack);
         }
 
-        NewRelic.recordError(error.name, error.message, error.stack, false);
+        NewRelic.recordError(error, false);
         this.setState({ error });
     }
 
@@ -266,7 +269,7 @@ const NewRelicLogger = store => next => action => {
         NewRelic.recordBreadcrumb("NewRelicLogger error", store.getState());
 
         // Record the JS error to New Relic
-        NewRelic.recordError(err.name, err.message, err.stack, false);
+        NewRelic.recordError(err, false);
     }
 }
 
@@ -303,7 +306,7 @@ Vue.config.errorHandler = (err, vm, info) => {
     NewRelic.recordBreadcrumb("Vue Error", { 'componentName': vm.$options.name, 'lifecycleHook': lifecycleHookInfo })
 
     // Record the JS error to New Relic
-    NewRelic.recordError(err.name, err.message, err.stack, false);
+    NewRelic.recordError(error, false);
 }
 ```
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -127,17 +127,26 @@ exports.defineAutoTests = () => {
       spyOn(cordova, "exec").and.callThrough();
       spyOn(window.console, "warn").and.callThrough();
 
-      let exampleError = new TypeError;
-      window.NewRelic.recordError(exampleError.name, exampleError.message, exampleError.stack, true);
-      window.NewRelic.recordError('fakeErrorName', 'fakeMsg', 'fakeStack', false);
+      let exampleError = new Error();
+      exampleError.name = 'fakeErrorName';
+      exampleError.message = 'fakeMsg';
+      exampleError.stack = 'fakeStack';
+      window.NewRelic.recordError(exampleError, true);
+      window.NewRelic.recordError(new TypeError, false);
+      window.NewRelic.recordError(new EvalError, true);
+      window.NewRelic.recordError(new RangeError, false);
+      window.NewRelic.recordError(new ReferenceError, true);
+      window.NewRelic.recordError(new Error, false);
 
       // Bad arguments
-      window.NewRelic.recordError(null, 'fakeMsg', 'fakeStack', false);
-      window.NewRelic.recordError('fakeErrorName', null, 'fakeStack', true);
+      window.NewRelic.recordError(undefined, false);
+      window.NewRelic.recordError(null, true);
+      window.NewRelic.recordError(123, true);
+      window.NewRelic.recordError(true, false);
 
       let numOfNativeCalls = cordova.exec.calls.count() - window.console.warn.calls.count();
-      expect(numOfNativeCalls).toBe(2);
-      expect(window.NewRelic.recordError).toHaveBeenCalledTimes(4);
+      expect(numOfNativeCalls).toBe(6);
+      expect(window.NewRelic.recordError).toHaveBeenCalledTimes(10);
     });
 
     it('should have currentSessionId', () => {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -131,18 +131,18 @@ exports.defineAutoTests = () => {
       exampleError.name = 'fakeErrorName';
       exampleError.message = 'fakeMsg';
       exampleError.stack = 'fakeStack';
-      window.NewRelic.recordError(exampleError, true);
-      window.NewRelic.recordError(new TypeError, false);
-      window.NewRelic.recordError(new EvalError, true);
-      window.NewRelic.recordError(new RangeError, false);
-      window.NewRelic.recordError(new ReferenceError, true);
-      window.NewRelic.recordError(new Error, false);
+      window.NewRelic.recordError(exampleError);
+      window.NewRelic.recordError(new TypeError);
+      window.NewRelic.recordError(new EvalError);
+      window.NewRelic.recordError(new RangeError);
+      window.NewRelic.recordError(new ReferenceError);
+      window.NewRelic.recordError(new Error);
 
       // Bad arguments
-      window.NewRelic.recordError(undefined, false);
-      window.NewRelic.recordError(null, true);
-      window.NewRelic.recordError(123, true);
-      window.NewRelic.recordError(true, false);
+      window.NewRelic.recordError(undefined);
+      window.NewRelic.recordError(null);
+      window.NewRelic.recordError(123);
+      window.NewRelic.recordError(true);
 
       let numOfNativeCalls = cordova.exec.calls.count() - window.console.warn.calls.count();
       expect(numOfNativeCalls).toBe(6);

--- a/types/newrelic.d.ts
+++ b/types/newrelic.d.ts
@@ -8,15 +8,12 @@ export function recordCustomEvent(eventType: string, eventName: string, attribut
 export function startInteraction(actionName: string, cb: Function, fail: any): Promise<any>;
 export function endInteraction(interactionId: string, cb: any, fail: any): void;
 export function sendConsole(type: any, args: any): void;
-export function sendConsole(type: any, args: any): void;
-export function send(name: any, args: any): void;
 export function send(name: any, args: any): void;
 /**
  * Records JavaScript errors for Cordova.
  * @param {Error} err The name of the error.
- * @param {boolean} isFatal The flag for whether the error is fatal.
  */
-export function recordError(err: Error, isFatal: boolean, cb: any, fail: any): void;
+export function recordError(err: Error, cb: any, fail: any): void;
 export function crashNow(message: string, cb: any, fail: any): void;
 export function currentSessionId(cb: Function, fail: any): Promise<any>;
 export function incrementAttribute(name: string, value: number, cb: any, fail: any): void;

--- a/types/newrelic.d.ts
+++ b/types/newrelic.d.ts
@@ -12,21 +12,11 @@ export function sendConsole(type: any, args: any): void;
 export function send(name: any, args: any): void;
 export function send(name: any, args: any): void;
 /**
- * Records JavaScript errors for cordova.
- * @param {string} name The name of the error.
- * @param {string} message The message of the error.
- * @param {string} stack The error stack of the error.
+ * Records JavaScript errors for Cordova.
+ * @param {Error} err The name of the error.
  * @param {boolean} isFatal The flag for whether the error is fatal.
  */
-export function recordError(name: string, message: string, stack: string, isFatal: boolean, cb: any, fail: any): void;
-/**
- * Records JavaScript errors for cordova.
- * @param {string} name The name of the error.
- * @param {string} message The message of the error.
- * @param {string} stack The error stack of the error.
- * @param {boolean} isFatal The flag for whether the error is fatal.
- */
-export function recordError(name: string, message: string, stack: string, isFatal: boolean, cb: any, fail: any): void;
+export function recordError(err: Error, isFatal: boolean, cb: any, fail: any): void;
 export function crashNow(message: string, cb: any, fail: any): void;
 export function currentSessionId(cb: Function, fail: any): Promise<any>;
 export function incrementAttribute(name: string, value: number, cb: any, fail: any): void;

--- a/www/js/newrelic.js
+++ b/www/js/newrelic.js
@@ -126,9 +126,8 @@ var NewRelic = {
     /**
      * Records JavaScript errors for Cordova.
      * @param {Error} err The error to record.
-     * @param {boolean} isFatal The flag for whether the error is fatal.
      */
-    recordError(err, isFatal, cb, fail) {
+    recordError: function(err, cb, fail) {
         if (err) {
             var error;
 
@@ -141,7 +140,7 @@ var NewRelic = {
             }
 
             if(error !== undefined) {
-                cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordError", [error.name, error.message, error.stack, isFatal]);
+                cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordError", [error.name, error.message, error.stack, false]);
             } else {
                 window.console.warn('Undefined error in NewRelic.recordError');
             }
@@ -373,20 +372,20 @@ window.addEventListener("error", (event) => {
         err.name = event.message;
         err.message = event.error.message;
         err.stack = event.error.stack;
-        NewRelic.recordError(err, true);
+        NewRelic.recordError(err);
     } else if (cordova.platformId == "iOS") {
         const err = new Error();
         err.name = event.message;
         err.message = '';
         err.stack = '';
-        NewRelic.recordError(err, true);
+        NewRelic.recordError(err);
     }
 });
 
 try {
     window.addEventListener('unhandledrejection', (e) => {
         const err = new Error(`${e.reason}`)
-        NewRelic.recordError(err, true);
+        NewRelic.recordError(err);
     })
 } catch (err) {
     // do nothing -- addEventListener is not supported

--- a/www/js/newrelic.js
+++ b/www/js/newrelic.js
@@ -124,18 +124,30 @@ var NewRelic = {
     },
 
     /**
-     * Records JavaScript errors for cordova.
-     * @param {string} name The name of the error.
-     * @param {string} message The message of the error.
-     * @param {string} stack The error stack of the error.
+     * Records JavaScript errors for Cordova.
+     * @param {Error} err The error to record.
      * @param {boolean} isFatal The flag for whether the error is fatal.
      */
-    recordError(name, message, stack, isFatal, cb, fail) {
-        if(name === null || message == null) {
-            window.console.warn('undefined error name or message in recordError');
-            return;
+    recordError(err, isFatal, cb, fail) {
+        if (err) {
+            var error;
+
+            if (err instanceof Error) {
+                error = err;
+            }
+
+            if (typeof err === 'string') {
+                error = new Error(err || '');
+            }
+
+            if(error !== undefined) {
+                cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordError", [error.name, error.message, error.stack, isFatal]);
+            } else {
+                window.console.warn('Undefined error in NewRelic.recordError');
+            }
+
         } else {
-            cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordError", [name, message, stack, isFatal]);
+            window.console.warn('Error is required in NewRelic.recordError');
         }
     },
 
@@ -357,16 +369,24 @@ window.XMLHttpRequest.prototype.send = function (data) {
 window.addEventListener("error", (event) => {
     console.log(event);
     if (cordova.platformId == "android") {
-        NewRelic.recordError(event.message, event.error.message, event.error.stack, true);
+        const err = new Error();
+        err.name = event.message;
+        err.message = event.error.message;
+        err.stack = event.error.stack;
+        NewRelic.recordError(err, true);
     } else if (cordova.platformId == "iOS") {
-        NewRelic.recordError(event.message, "", "", true);
+        const err = new Error();
+        err.name = event.message;
+        err.message = '';
+        err.stack = '';
+        NewRelic.recordError(err, true);
     }
 });
 
 try {
     window.addEventListener('unhandledrejection', (e) => {
         const err = new Error(`${e.reason}`)
-        NewRelic.recordError(error.name, error.message, "", true);
+        NewRelic.recordError(err, true);
     })
 } catch (err) {
     // do nothing -- addEventListener is not supported


### PR DESCRIPTION
Refactored `recordError` to only take in an error for simpler use. All errors are not fatal in Cordova/Ionic, so we set the isFatal flag to false always in the call. The reference to the Error type is here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error